### PR TITLE
chore: update tailwindcss and its eslint-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "eslint-plugin-react": "^7.31.10",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-simple-import-sort": "^8.0.0",
-    "eslint-plugin-tailwindcss": "^3.6.2",
+    "eslint-plugin-tailwindcss": "^3.7.0",
     "eslint-plugin-testing-library": "^5.9.1",
     "eslint-plugin-unused-imports": "^2.0.0",
     "husky": "^8.0.1",
@@ -70,7 +70,7 @@
     "prettier": "^2.7.1",
     "rimraf": "^3.0.2",
     "start-server-and-test": "^1.14.0",
-    "tailwindcss": "^3.2.1",
+    "tailwindcss": "^3.2.4",
     "typescript": "^4.8.4"
   },
   "config": {


### PR DESCRIPTION
Quick MR updating packages:

- `tailwindcss`
- `eslint-plugin-tailwindcss`

The latest version of `eslint-plugin-tailwindcss`:

- add support for the new classes from `tailwindcss@3.2.0`
  - `collapse` (Visibility)
  - `content-baseline` (Align Content)
  - `place-baseline` (Place Content)
  - `place-items-baseline` (Place Items)
  - `break-keep` (Word Break)
  - Negative Outline Offset
- FIX: the classname ordering