### PR TITLE
Crank up Google PageSpeed Insights result

### DIFF
--- a/src/templates/Main.tsx
+++ b/src/templates/Main.tsx
@@ -18,7 +18,7 @@ const Main = (props: IMainProps) => (
           <h1 className="text-3xl font-bold text-gray-900">
             {AppConfig.title}
           </h1>
-          <h4 className="text-xl">{AppConfig.description}</h4>
+          <h2 className="text-xl">{AppConfig.description}</h2>
         </div>
         <nav>
           <ul className="flex flex-wrap text-xl">


### PR DESCRIPTION
This PR introduces two changes:

1. Replace the `<h4>` tag with `<h2>`. It fixes the issue with the SEO score. It's important to have header levels straight from 1 to 6 (or more).
2. Replace raw <img> HTML tag with NextJS <Image> tag. It will serve images with various srcset. It fixes the Google PageSpeed issue with unoptimized images. But there is a flaw. The project cover image gets messy due to optimization. Mixing blue React and TypeScript or VS Code with pink background color doesn't look great.