### PR TITLE
chore: fix commit hook if this project placed in subdir of git root

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx --no -- commitlint --edit $1
+cd "$(dirname "$0")/.." && npx --no -- commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 
 # Disable concurent to run `check-types` after ESLint in lint-staged
-npx lint-staged --concurrent false
+cd "$(dirname "$0")/.." && npx lint-staged --concurrent false


### PR DESCRIPTION
Ensure the commit hook works even if this project is placed not in the root directory of the git repository

Test if the commit hook works in both use cases manually.

Test in subdirectory of git root:

```bash
mdir test
cd test
git init
git clone -b chore/commit-hook-in-subdir git@github.com:sh1nj1/Next-js-Boilerplate.git --depth 1 \
web
cd web
rm -rf .git
npm install
git add .
git commit -m "chore: put next-js-boilerplate"
```

Test in git root:

```bash
git clone -b chore/commit-hook-in-subdir git@github.com:sh1nj1/Next-js-Boilerplate.git --depth 1 \
test-next-js-boilerplate
cd test-next-js-boilerplate
npm install
git add .
git commit -m "chore: test changes"
```