### PR TITLE
build: update eslint-plugin-tailwindcss to support tailwindcss@3.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-simple-import-sort": "^10.0.0",
         "eslint-plugin-storybook": "^0.6.15",
-        "eslint-plugin-tailwindcss": "^3.13.1",
+        "eslint-plugin-tailwindcss": "^3.14.0",
         "eslint-plugin-testing-library": "^6.2.0",
         "eslint-plugin-unused-imports": "^3.0.0",
         "http-server": "^14.1.1",
@@ -17073,9 +17073,9 @@
       }
     },
     "node_modules/eslint-plugin-tailwindcss": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-tailwindcss/-/eslint-plugin-tailwindcss-3.13.1.tgz",
-      "integrity": "sha512-2Nlgr9doO6vFAG9w4iGU0sspWXuzypfng10HTF+dFS2NterhweWtgdRvf/f7aaoOUUxVZM8wMIXzazrZ7CxyeA==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-tailwindcss/-/eslint-plugin-tailwindcss-3.14.0.tgz",
+      "integrity": "sha512-SGy4JmZoP5m1bXCbcsPfQg1/axOdriJf9L22HghNMyDTM5mybg2XEkaMwgax4aR13zZJRRB1nWmkuYUn+SV6/Q==",
       "dev": true,
       "dependencies": {
         "fast-glob": "^3.2.5",
@@ -17085,7 +17085,7 @@
         "node": ">=12.13.0"
       },
       "peerDependencies": {
-        "tailwindcss": "^3.3.2"
+        "tailwindcss": "^3.4.0"
       }
     },
     "node_modules/eslint-plugin-testing-library": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "eslint-plugin-storybook": "^0.6.15",
-    "eslint-plugin-tailwindcss": "^3.13.1",
+    "eslint-plugin-tailwindcss": "^3.14.0",
     "eslint-plugin-testing-library": "^6.2.0",
     "eslint-plugin-unused-imports": "^3.0.0",
     "http-server": "^14.1.1",


### PR DESCRIPTION
I just released `eslint-plugin-tailwindcss@3.14.0` which supports the new features from `tailwindcss@3.4.0`.

This branch uses the latest version of the eslint plugin.