### PR TITLE
Remove prettier from eslint rules, add prettier config file

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,17 +3,8 @@
   "extends": [
     "airbnb-base",
     "next/core-web-vitals", // Needed to avoid warning in next.js build: 'The Next.js plugin was not detected in your ESLint configuration'
-    "plugin:prettier/recommended"
+    "prettier"
   ],
-  "rules": {
-    "prettier/prettier": [
-      "error",
-      {
-        "singleQuote": true,
-        "endOfLine": "auto"
-      }
-    ] // Avoid conflict rule between Prettier and Airbnb Eslint
-  },
   "overrides": [
     // Configuration for TypeScript files
     {
@@ -29,19 +20,12 @@
         "airbnb",
         "airbnb-typescript",
         "next/core-web-vitals",
-        "plugin:prettier/recommended"
+        "prettier"
       ],
       "parserOptions": {
         "project": "./tsconfig.json"
       },
       "rules": {
-        "prettier/prettier": [
-          "error",
-          {
-            "singleQuote": true,
-            "endOfLine": "auto"
-          }
-        ], // Avoid conflict rule between Prettier and Airbnb Eslint
         "import/extensions": "off", // Avoid missing file extension errors, TypeScript already provides a similar feature
         "react/function-component-definition": "off", // Disable Airbnb's specific function type
         "react/destructuring-assignment": "off", // Vscode doesn't support automatically destructuring, it's a pain to add a new variable

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
     "package-lock.json": true
   },
   "editor.defaultFormatter": "dbaeumer.vscode-eslint",
-  "editor.formatOnSave": false,
+  "editor.formatOnSave": true,
   "editor.codeActionsOnSave": [
     "source.addMissingImports",
     "source.fixAll.eslint"

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "eslint-plugin-jest-formatting": "^3.1.0",
     "eslint-plugin-jsx-a11y": "^6.8.0",
     "eslint-plugin-playwright": "^1.5.1",
-    "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-simple-import-sort": "^12.0.0",

--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -1,0 +1,7 @@
+/** @type {import("prettier").Config} */
+const config = {
+  endOfLine: 'auto',
+  singleQuote: true,
+};
+
+export default config;


### PR DESCRIPTION
I think it would be better if the responsibility of formatting files was left up to the user on `format on save` or also to be enforced by husky (like already does in this template).

In my opinion Prettier should format things, ESLint should lint things, having ESLint check for format should not be its responsibility.

The official Prettier docs explain why you might not want ESLint do formatting checks: https://prettier.io/docs/en/integrating-with-linters.html

Here's Theo explaining it better than I could: https://www.youtube.com/watch?v=Cd-gBxzcsdA