### PR TITLE
feat: run migration only in development and eslint-disable need to be…

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,5 @@
-import { withSentryConfig } from '@sentry/nextjs';
 /* eslint-disable import/no-extraneous-dependencies, import/extensions */
+import { withSentryConfig } from '@sentry/nextjs';
 import './src/libs/Env.mjs';
 import withBundleAnalyzer from '@next/bundle-analyzer';
 import withNextIntl from 'next-intl/plugin';

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -33,7 +33,7 @@ export default defineConfig({
   // Run your local dev server before starting the tests:
   // https://playwright.dev/docs/test-advanced#launching-a-development-web-server-during-the-tests
   webServer: {
-    command: process.env.CI ? 'npm run start' : 'npm run dev',
+    command: process.env.CI ? 'npm run start' : 'npm run dev:next',
     url: baseURL,
     timeout: 2 * 60 * 1000,
     reuseExistingServer: !process.env.CI,

--- a/src/libs/DB.ts
+++ b/src/libs/DB.ts
@@ -14,6 +14,6 @@ export const db = drizzle(client);
 // Disable migrate function if using Edge runtime and use `npm run db:migrate` instead.
 // Only run migrate in development. Otherwise, migrate will also be run during the build which can cause errors.
 // Migrate during the build can cause errors due to the locked database when multiple migrations are running at the same time.
-if (process.env.NODE_ENV !== 'production') {
+if (process.env.NODE_ENV === 'development') {
   await migrate(db, { migrationsFolder: './migrations' });
 }


### PR DESCRIPTION
… at the top