### PR TITLE
docs(README): use correct light image pathname

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Clone this project and use it to create your own [Next.js](https://nextjs.org) p
     <td align="center" width="33%">
       <a href="https://turso.tech/?utm_source=nextjsstarterbp">
         <picture>
-          <source media="(prefers-color-scheme: dark)" srcset="public/assets/images/turso-white.png?raw=true">
+          <source media="(prefers-color-scheme: dark)" srcset="public/assets/images/turso-light.png?raw=true">
           <source media="(prefers-color-scheme: light)" srcset="public/assets/images/turso-dark.png?raw=true">
           <img alt="Turso - SQLite for Production" src="public/assets/images/turso-dark.png?raw=true">
         </picture>


### PR DESCRIPTION
The filename was incorrect for dark mode.