### PR TITLE
style: add entuent.fira-code-nerd-font extension and settings

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -9,6 +9,7 @@
     "yoavbls.pretty-ts-errors",
     "ms-playwright.playwright",
     "github.vscode-github-actions",
-    "lokalise.i18n-ally"
+    "lokalise.i18n-ally",
+    "entuent.fira-code-nerd-font"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,11 @@
     "package-lock.json": true
   },
 
+  // FiraCode font
+  "workbench.iconTheme": "fira-code-material-minimal",
+  "editor.fontFamily": "fira-code-nerd, FiraCode Nerd Font, Consolas, 'Courier New', monospace",
+  "editor.fontLigatures": true,
+
   // TypeScript
   "typescript.tsdk": "node_modules/typescript/lib", // Use the workspace version of TypeScript
   "typescript.enablePromptUseWorkspaceTsdk": true, // For security reasons it's require that users opt into using the workspace version of typescript


### PR DESCRIPTION
Does it make sense to add Fira Code font? I used one of extensions that add it to vscode
![image](https://github.com/user-attachments/assets/2b0f8556-2356-45c6-99de-d29c55c12e1c)
