### PR TITLE
Refactor: Update import path for LocalePrefixMode to package-level reference

### DIFF
--- a/src/utils/AppConfig.ts
+++ b/src/utils/AppConfig.ts
@@ -1,4 +1,4 @@
-import type { LocalePrefixMode } from 'node_modules/next-intl/dist/types/src/routing/types';
+import type { LocalePrefixMode } from 'next-intl/routing';
 
 const localePrefix: LocalePrefixMode = 'as-needed';
 


### PR DESCRIPTION
This PR updates the import path for `LocalePrefixMode` to use a general, package-level reference instead of an internal, overly specific one. This change simplifies the import structure and improves maintainability.

### Related Issue
Fixes #367

### Changes
- Refactored import path for `LocalePrefixMode` in `utils/AppConfig`.
- Ensured the import path is now based on the package-level reference instead of an internal one.

### Notes
- No functional changes were made, only the import path was updated.
