### PR TITLE
fix(arcjet): move Arcjet to middleware to avoid re-renders

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ Arcjet is configured with two main features: bot detection and the Arcjet Shield
 - [Bot detection](https://docs.arcjet.com/bot-protection/concepts) is configured to allow search engines, preview link generators e.g. Slack and Twitter previews, and to allow common uptime monitoring services. All other bots, such as scrapers and AI crawlers, will be blocked. You can [configure additional bot types](https://docs.arcjet.com/bot-protection/identifying-bots) to allow or block.
 - [Arcjet Shield WAF](https://docs.arcjet.com/shield/concepts) will detect and block common attacks such as SQL injection, cross-site scripting, and other OWASP Top 10 vulnerabilities.
 
-Arcjet is configured with a central client at `src/libs/Arcjet.ts` that includes the Shield WAF rules. Additional rules are configured in `src/app/[locale]/layout.tsx` based on the page type.
+Arcjet is configured with a central client at `src/libs/Arcjet.ts` that includes the Shield WAF rules. Additional rules are applied when Arcjet is called in `middleware.ts`.
 
 ### Useful commands
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "next-js-boilerplate",
       "version": "3.65.0",
       "dependencies": {
-        "@arcjet/next": "1.0.0-beta.3",
+        "@arcjet/next": "1.0.0-beta.4",
         "@clerk/localizations": "^3.13.1",
         "@clerk/nextjs": "^6.12.9",
         "@electric-sql/pglite": "^0.2.17",
@@ -257,88 +257,88 @@
       }
     },
     "node_modules/@arcjet/analyze": {
-      "version": "1.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@arcjet/analyze/-/analyze-1.0.0-beta.3.tgz",
-      "integrity": "sha512-CbdvkAOYPgQVM+pF7JsRvvusEUs09u+8P7dIGT16jUZyQGIO2v4sUViDckoNgNidFCDwcNlJFHKwHJUVZjCFyQ==",
+      "version": "1.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@arcjet/analyze/-/analyze-1.0.0-beta.4.tgz",
+      "integrity": "sha512-soaLcau7IuN4iwcnESXVrly+7L5rdH5AiZ4MZzF+MbFMGJJozjttEIlBDXZBBKxk38TJDVFVfnaPScejdx6tfQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/analyze-wasm": "1.0.0-beta.3",
-        "@arcjet/protocol": "1.0.0-beta.3"
+        "@arcjet/analyze-wasm": "1.0.0-beta.4",
+        "@arcjet/protocol": "1.0.0-beta.4"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@arcjet/analyze-wasm": {
-      "version": "1.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@arcjet/analyze-wasm/-/analyze-wasm-1.0.0-beta.3.tgz",
-      "integrity": "sha512-JV4FxHnL2QnLmF5VgYhgGL0aAmWa0kP+gut20fAMuEby3jyqCdxzE/+vKfZEPNdKQLO46H5XCvjHnAx18nmOtw==",
+      "version": "1.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@arcjet/analyze-wasm/-/analyze-wasm-1.0.0-beta.4.tgz",
+      "integrity": "sha512-Y/u8OEcriTAzVAunUVbLiRnQ6BDYU4v7cckEXCsvSrZ2b1KCB93JDkCaUMtoA4lDzvIM9HNRdE4OIhh+PaGmzQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@arcjet/duration": {
-      "version": "1.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@arcjet/duration/-/duration-1.0.0-beta.3.tgz",
-      "integrity": "sha512-1G5qcuz1xhxEUztYpAMQz2Jp2BPch2A9hn1aK/04hoGrpKi79z1hjoTglSftbhAJvE+wwYN764VcCFjmBK793g==",
+      "version": "1.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@arcjet/duration/-/duration-1.0.0-beta.4.tgz",
+      "integrity": "sha512-K1YHseq0KHH8HstVPE4jtrNMGxhIh/0+Y8s72Npui+pzS1bmrfYYm3ZNslVVLWJOsL3vDorfp3ChzWm4dAQLcQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@arcjet/env": {
-      "version": "1.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@arcjet/env/-/env-1.0.0-beta.3.tgz",
-      "integrity": "sha512-oUppsM8wL6I1cte9SJc/aZ3OI73hDnGDUTNXYN+Q2bfhuDVyJa0j6y/uQBG0FduPYg1Clwqy/39XS1u4MOQD8g==",
+      "version": "1.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@arcjet/env/-/env-1.0.0-beta.4.tgz",
+      "integrity": "sha512-3QAdhN/cr6m82eNVlcij/TcdsSfuCNXsH4z/biLss7ecGJAR+56YGBVyit0gnDUM7E8QAMWYoX5612p5BQqJJw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@arcjet/headers": {
-      "version": "1.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@arcjet/headers/-/headers-1.0.0-beta.3.tgz",
-      "integrity": "sha512-bo+0k0cf8A9ToqMJKSiyTpK4oYHY7xUsTibvM3WZkNu1QXrjM1y+P3tEwcyn9nMHSEtlRkr0TPJPerRqm3Z9fg==",
+      "version": "1.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@arcjet/headers/-/headers-1.0.0-beta.4.tgz",
+      "integrity": "sha512-NYMoRY63lDg0SguVGz6/ojX+wrY2Kd5Skt38WkRc4yTFYwsx4uZOxWlZFRsXzi4G+LR2Zxp8nLpAF3iFhlBwTQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@arcjet/ip": {
-      "version": "1.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@arcjet/ip/-/ip-1.0.0-beta.3.tgz",
-      "integrity": "sha512-z2yAfJwZTyXXlEJJFXOypB0FYEzPaG1YXeRpHvrfrBhl1pZFTSX70PJkz1uIVM0Cq+H5FpMr3QdvjVzdFNLHBw==",
+      "version": "1.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@arcjet/ip/-/ip-1.0.0-beta.4.tgz",
+      "integrity": "sha512-vVKONeu8uX2J+dS0Lm/PsdmdB+WXqG5zR1NnYvp9L/QrjYw+SMusmDwCUseCwMkoQ7vDLrGZvFD/otL1Nap2cw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@arcjet/logger": {
-      "version": "1.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@arcjet/logger/-/logger-1.0.0-beta.3.tgz",
-      "integrity": "sha512-KWYsWnSn6kFNT5pS85V+bFd3gu+x0Z+UbaclpQqfCrBoS08dUAZQbt+IFU1KVazgAMXwZ+OC16llF9Z9Ne1dUQ==",
+      "version": "1.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@arcjet/logger/-/logger-1.0.0-beta.4.tgz",
+      "integrity": "sha512-TrUluhFb+WcCKjzl5pR/JQsL3pcDEorSjcwSKm9Z/AmZvCmjrahU4LsFVw5pjgVbBT6/PbpzoE29ovn25lpMTQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/sprintf": "1.0.0-beta.3"
+        "@arcjet/sprintf": "1.0.0-beta.4"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@arcjet/next": {
-      "version": "1.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@arcjet/next/-/next-1.0.0-beta.3.tgz",
-      "integrity": "sha512-IchLspfeIuOhy1a3z8cuvfnYzjl2ehnXNeNWoK0gx1d0URRev2U/7BsUqpPckLbYfFA/kLpfPjcL9f4yMppV0Q==",
+      "version": "1.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@arcjet/next/-/next-1.0.0-beta.4.tgz",
+      "integrity": "sha512-NqQvd90JtTYdFTbPR19E+LBjrOIaIEKoD4AQyUEDkSZzLwUl2JGBDKowgy4uWHeCWwgJJl4HYOS+YtKfG45f2g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/env": "1.0.0-beta.3",
-        "@arcjet/headers": "1.0.0-beta.3",
-        "@arcjet/ip": "1.0.0-beta.3",
-        "@arcjet/logger": "1.0.0-beta.3",
-        "@arcjet/protocol": "1.0.0-beta.3",
-        "@arcjet/transport": "1.0.0-beta.3",
-        "arcjet": "1.0.0-beta.3"
+        "@arcjet/env": "1.0.0-beta.4",
+        "@arcjet/headers": "1.0.0-beta.4",
+        "@arcjet/ip": "1.0.0-beta.4",
+        "@arcjet/logger": "1.0.0-beta.4",
+        "@arcjet/protocol": "1.0.0-beta.4",
+        "@arcjet/transport": "1.0.0-beta.4",
+        "arcjet": "1.0.0-beta.4"
       },
       "engines": {
         "node": ">=18"
@@ -348,9 +348,9 @@
       }
     },
     "node_modules/@arcjet/protocol": {
-      "version": "1.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@arcjet/protocol/-/protocol-1.0.0-beta.3.tgz",
-      "integrity": "sha512-BGMAmJszi9D6oaV6t28L/B9Cf8xcWSAQ24l2uYmoipsymBF6Ss7vjQxOzhf1++g0v7CaEZlBPf7HVV/n1Nj4aw==",
+      "version": "1.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@arcjet/protocol/-/protocol-1.0.0-beta.4.tgz",
+      "integrity": "sha512-eTF5bY5ub6CfGFH4QfeyCINg33Fhc/voWvJ8WNJXN8X3wcWpnq8TpPLPfZlB6B/x6sjOzj+b9JzyeqvczW2qgg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "1.10.0",
@@ -362,29 +362,30 @@
       }
     },
     "node_modules/@arcjet/runtime": {
-      "version": "1.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@arcjet/runtime/-/runtime-1.0.0-beta.3.tgz",
-      "integrity": "sha512-Aw4Wj8hCUyrW4AIntd+3QEnTUGTkk8Y6OQMoKrggyDVo3T9Acdij+Bhtma4zWfgwKqFRzj8J650EkCmD9qpFrw==",
+      "version": "1.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@arcjet/runtime/-/runtime-1.0.0-beta.4.tgz",
+      "integrity": "sha512-mzhE5pPV74x7xfDqxIv4qPKNyYNQP4BE9W9lMhUO3NcRYuHDqYamvAhSKYQQWBs8lKx9AiaidOKo6QMaQ+udPw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@arcjet/sprintf": {
-      "version": "1.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@arcjet/sprintf/-/sprintf-1.0.0-beta.3.tgz",
-      "integrity": "sha512-veWXxhLgYJBf8Jf7PJemfC0xksJrmP/LjzUzZl9qs+asjRUJ4Qrz6NO24focn9b3jCHkRznG/YzDyUDtZ0eePg==",
+      "version": "1.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@arcjet/sprintf/-/sprintf-1.0.0-beta.4.tgz",
+      "integrity": "sha512-kvbLE5+ghsGaEpA/QwRsQQzaHnDco0fnsskofulrB4S6DZZdjBIarJjf0OTFLrGAp3BQFPp9u45h6XcRfj+A7Q==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@arcjet/transport": {
-      "version": "1.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@arcjet/transport/-/transport-1.0.0-beta.3.tgz",
-      "integrity": "sha512-CRdhcEepFCBwd0BmmYMc6fxhWpcw6lQw/g4j7BVdGSPJHIE1HVTiE3pIP6CsSBedb+ihRpD45Cbi/lZD4BDFLQ==",
+      "version": "1.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@arcjet/transport/-/transport-1.0.0-beta.4.tgz",
+      "integrity": "sha512-zbxSxpbKolbhvyHOnaCJe8JIgZ5BbO+Lf9jB6xHKhnP6uK9V9afwBhQfyu4dIBtK6XEsofDSQ/qkzPN9rl48TA==",
       "license": "Apache-2.0",
       "dependencies": {
+        "@bufbuild/protobuf": "1.10.0",
         "@connectrpc/connect": "1.6.1",
         "@connectrpc/connect-node": "1.6.1",
         "@connectrpc/connect-web": "1.6.1"
@@ -13397,16 +13398,16 @@
       "license": "MIT"
     },
     "node_modules/arcjet": {
-      "version": "1.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/arcjet/-/arcjet-1.0.0-beta.3.tgz",
-      "integrity": "sha512-60pL1+vzRZOEb83lbV041TXd/C3KPjWjb1W3Kml7DBhFHDgfK/g1Vl63pPswzHKDu9Tr3N84pU2HfXMe2qoelw==",
+      "version": "1.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/arcjet/-/arcjet-1.0.0-beta.4.tgz",
+      "integrity": "sha512-VOaq23msJDEsoxHyLqKMVQPBHCLWRTJooXXXlYZ3KdvMPwQ8foaklMvYHAVkH4abwHrSPKC3prb173ps3QVB+Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/analyze": "1.0.0-beta.3",
-        "@arcjet/duration": "1.0.0-beta.3",
-        "@arcjet/headers": "1.0.0-beta.3",
-        "@arcjet/protocol": "1.0.0-beta.3",
-        "@arcjet/runtime": "1.0.0-beta.3"
+        "@arcjet/analyze": "1.0.0-beta.4",
+        "@arcjet/duration": "1.0.0-beta.4",
+        "@arcjet/headers": "1.0.0-beta.4",
+        "@arcjet/protocol": "1.0.0-beta.4",
+        "@arcjet/runtime": "1.0.0-beta.4"
       },
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@arcjet/next": "1.0.0-beta.3",
+    "@arcjet/next": "1.0.0-beta.4",
     "@clerk/localizations": "^3.13.1",
     "@clerk/nextjs": "^6.12.9",
     "@electric-sql/pglite": "^0.2.17",

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,8 +1,6 @@
 import type { Metadata } from 'next';
 import { PostHogProvider } from '@/components/analytics/PostHogProvider';
 import { DemoBadge } from '@/components/DemoBadge';
-import arcjet, { detectBot, request } from '@/libs/Arcjet';
-import { Env } from '@/libs/Env';
 import { routing } from '@/libs/i18nNavigation';
 import { NextIntlClientProvider } from 'next-intl';
 import { getMessages, setRequestLocale } from 'next-intl/server';
@@ -38,20 +36,6 @@ export function generateStaticParams() {
   return routing.locales.map(locale => ({ locale }));
 }
 
-// Improve security with Arcjet
-const aj = arcjet.withRule(
-  detectBot({
-    mode: 'LIVE',
-    // Block all bots except the following
-    allow: [
-      // See https://docs.arcjet.com/bot-protection/identifying-bots
-      'CATEGORY:SEARCH_ENGINE', // Allow search engines
-      'CATEGORY:PREVIEW', // Allow preview links to show OG images
-      'CATEGORY:MONITOR', // Allow uptime monitoring services
-    ],
-  }),
-);
-
 export default async function RootLayout(props: {
   children: React.ReactNode;
   params: Promise<{ locale: string }>;
@@ -63,22 +47,6 @@ export default async function RootLayout(props: {
   }
 
   setRequestLocale(locale);
-
-  // Verify the request with Arcjet
-  if (Env.ARCJET_KEY) {
-    const req = await request();
-    const decision = await aj.protect(req);
-
-    // These errors are handled by the global error boundary, but you could also
-    // redirect or show a custom error page
-    if (decision.isDenied()) {
-      if (decision.reason.isBot()) {
-        throw new Error('No bots allowed');
-      }
-
-      throw new Error('Access denied');
-    }
-  }
 
   // Using internationalization in Client Components
   const messages = await getMessages();

--- a/src/libs/Arcjet.ts
+++ b/src/libs/Arcjet.ts
@@ -1,6 +1,5 @@
 import arcjet, { shield } from '@arcjet/next';
 import { Env } from './Env';
-import { logger } from './Logger';
 
 // Re-export the rules to simplify imports inside handlers
 export {
@@ -26,5 +25,4 @@ export default arcjet({
     }),
     // Other rules are added in different routes
   ],
-  log: logger,
 });


### PR DESCRIPTION
In Arcjet beta 4 a change was made to only log the local development IP warning when the Arcjet client is instantiated. The previous behavior was to log on every request.

On upgrading to beta 4, it the warning was being logged on every request. After discussion in https://github.com/arcjet/arcjet-js/issues/3683 we think that this is because of the `layout.tsx` causing a re-render for every request.

This PR moves Arcjet to the middleware before Clerk so that it can protect every request as configured in the matcher.