### PR TITLE
ci: add IF NOT EXISTS to counter table creation

### DIFF
--- a/migrations/0000_init-db.sql
+++ b/migrations/0000_init-db.sql
@@ -1,6 +1,6 @@
-CREATE TABLE "counter" (
-	"id" serial PRIMARY KEY NOT NULL,
-	"count" integer DEFAULT 0,
-	"updated_at" timestamp DEFAULT now() NOT NULL,
-	"created_at" timestamp DEFAULT now() NOT NULL
+CREATE TABLE IF NOT EXISTS "counter" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "count" integer DEFAULT 0,
+  "updated_at" timestamp DEFAULT now() NOT NULL,
+  "created_at" timestamp DEFAULT now() NOT NULL
 );


### PR DESCRIPTION
When running `npm run build:next`  the database reports an error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved database migration to prevent errors when creating the "counter" table if it already exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->