### PR TITLE
fix: ensure counter updates are fully committed before page refresh in counter form

### DIFF
--- a/src/components/CounterForm.tsx
+++ b/src/components/CounterForm.tsx
@@ -17,13 +17,14 @@ export const CounterForm = () => {
   const router = useRouter();
 
   const handleIncrement = form.handleSubmit(async (data) => {
-    await fetch(`/api/counter`, {
+    const response = await fetch(`/api/counter`, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(data),
     });
+    await response.json();
 
     form.reset();
     router.refresh();

--- a/src/components/CurrentCount.tsx
+++ b/src/components/CurrentCount.tsx
@@ -11,10 +11,10 @@ export const CurrentCount = async () => {
   // `x-e2e-random-id` is used for end-to-end testing to make isolated requests
   // The default value is 0 when there is no `x-e2e-random-id` header
   const id = Number((await headers()).get('x-e2e-random-id')) ?? 0;
-  const result = await db.query.counterSchema.findMany({
+  const result = await db.query.counterSchema.findFirst({
     where: eq(counterSchema.id, id),
   });
-  const count = result[0]?.count ?? 0;
+  const count = result?.count ?? 0;
 
   logger.info('Counter fetched successfully');
 

--- a/tests/e2e/Counter.e2e.ts
+++ b/tests/e2e/Counter.e2e.ts
@@ -44,6 +44,12 @@ test.describe('Counter', () => {
       await page.getByRole('button', { name: 'Increment' }).click();
 
       await expect(page.getByText('Count:')).toHaveText(`Count: ${countNumber + 2}`);
+
+      await page.getByLabel('Increment by').fill('3');
+      await page.getByRole('button', { name: 'Increment' }).isEnabled();
+      await page.getByRole('button', { name: 'Increment' }).click();
+
+      await expect(page.getByText('Count:')).toHaveText(`Count: ${countNumber + 5}`);
     });
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Counter updates now wait for the server response before refreshing, improving reliability after increments.
  - Current count display is more robust and correctly defaults to 0 when no record exists.

- Tests
  - Expanded end-to-end coverage to validate multiple sequential increments in a single session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->