### PR TITLE
fix: resolve counter display inconsistency due to Next.js caching

### DIFF
--- a/src/app/[locale]/(marketing)/counter/page.tsx
+++ b/src/app/[locale]/(marketing)/counter/page.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from 'next';
 import { useTranslations } from 'next-intl';
 import { getTranslations } from 'next-intl/server';
 import Image from 'next/image';
-import { Suspense } from 'react';
 import { CounterForm } from '@/components/CounterForm';
 import { CurrentCount } from '@/components/CurrentCount';
 
@@ -29,9 +28,7 @@ export default function Counter() {
       <CounterForm />
 
       <div className="mt-3">
-        <Suspense fallback={<p>{t('loading_counter')}</p>}>
-          <CurrentCount />
-        </Suspense>
+        <CurrentCount />
       </div>
 
       <div className="mt-5 text-center text-sm">

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -19,7 +19,6 @@
   "Counter": {
     "meta_title": "Counter",
     "meta_description": "An example of DB operation",
-    "loading_counter": "Loading counter...",
     "security_powered_by": "Security, bot detection and rate limiting powered by"
   },
   "CounterForm": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -19,7 +19,6 @@
   "Counter": {
     "meta_title": "Compteur",
     "meta_description": "Un exemple d'opération DB",
-    "loading_counter": "Chargement du compteur...",
     "security_powered_by": "Sécurité, détection de bot et rate limiting propulsés par"
   },
   "CounterForm": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified the Counter page by removing the loading state; the counter now renders directly without a fallback.
  * Cleaned up locales by removing unused loading message entries in English and French.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->