### PR TITLE
chore: update Checkly region from eu-west-1 to eu-central-1

### DIFF
--- a/checkly.config.ts
+++ b/checkly.config.ts
@@ -17,7 +17,7 @@ export const config = defineConfig({
   logicalId: process.env.CHECKLY_LOGICAL_ID ?? '',
   repoUrl: 'https://github.com/ixartz/Next-js-Boilerplate',
   checks: {
-    locations: ['us-east-1', 'eu-west-1'],
+    locations: ['us-east-1', 'eu-central-1'],
     tags: ['website'],
     runtimeId: '2024.02',
     browserChecks: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated monitoring infrastructure configuration, changing the default monitoring region for health checks from EU-West to EU-Central.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->