### PR TITLE
fix: udpate to next.js 16.0.7, critical issue with RSC in next.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@next/bundle-analyzer": "^16.0.7",
         "@next/eslint-plugin-next": "^16.0.7",
         "@playwright/test": "^1.57.0",
-        "@spotlightjs/spotlight": "^4.7.0",
+        "@spotlightjs/spotlight": "4.5.1",
         "@storybook/addon-a11y": "^10.1.4",
         "@storybook/addon-docs": "^10.1.4",
         "@storybook/addon-vitest": "^10.1.4",
@@ -9966,199 +9966,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@sentry/electron": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@sentry/electron/-/electron-7.4.0.tgz",
-      "integrity": "sha512-MrJKe3tJ7s/Wllw9KaTKgnn+qfc5n7M4prcfjS21JdJtSXnj0P6V6CoWTnQ6gHXXURdBef+4H54tYhOJYXftRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/browser": "10.27.0",
-        "@sentry/core": "10.27.0",
-        "@sentry/node": "10.27.0"
-      },
-      "peerDependencies": {
-        "@sentry/node-native": "10.27.0"
-      },
-      "peerDependenciesMeta": {
-        "@sentry/node-native": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@sentry/electron/node_modules/@sentry-internal/browser-utils": {
-      "version": "10.27.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.27.0.tgz",
-      "integrity": "sha512-17tO6AXP+rmVQtLJ3ROQJF2UlFmvMWp7/8RDT5x9VM0w0tY31z8Twc0gw2KA7tcDxa5AaHDUbf9heOf+R6G6ow==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "10.27.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry/electron/node_modules/@sentry-internal/feedback": {
-      "version": "10.27.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.27.0.tgz",
-      "integrity": "sha512-UecsIDJcv7VBwycge/MDvgSRxzevDdcItE1i0KSwlPz00rVVxLY9kV28PJ4I2E7r6/cIaP9BkbWegCEcv09NuA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "10.27.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry/electron/node_modules/@sentry-internal/replay": {
-      "version": "10.27.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.27.0.tgz",
-      "integrity": "sha512-tKSzHq1hNzB619Ssrqo25cqdQJ84R3xSSLsUWEnkGO/wcXJvpZy94gwdoS+KmH18BB1iRRRGtnMxZcUkiPSesw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/browser-utils": "10.27.0",
-        "@sentry/core": "10.27.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry/electron/node_modules/@sentry-internal/replay-canvas": {
-      "version": "10.27.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.27.0.tgz",
-      "integrity": "sha512-inhsRYSVBpu3BI1kZphXj6uB59baJpYdyHeIPCiTfdFNBE5tngNH0HS/aedZ1g9zICw290lwvpuyrWJqp4VBng==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/replay": "10.27.0",
-        "@sentry/core": "10.27.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry/electron/node_modules/@sentry/browser": {
-      "version": "10.27.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.27.0.tgz",
-      "integrity": "sha512-G8q362DdKp9y1b5qkQEmhTFzyWTOVB0ps1rflok0N6bVA75IEmSDX1pqJsNuY3qy14VsVHYVwQBJQsNltQLS0g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/browser-utils": "10.27.0",
-        "@sentry-internal/feedback": "10.27.0",
-        "@sentry-internal/replay": "10.27.0",
-        "@sentry-internal/replay-canvas": "10.27.0",
-        "@sentry/core": "10.27.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry/electron/node_modules/@sentry/core": {
-      "version": "10.27.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.27.0.tgz",
-      "integrity": "sha512-Zc68kdH7tWTDtDbV1zWIbo3Jv0fHAU2NsF5aD2qamypKgfSIMSbWVxd22qZyDBkaX8gWIPm/0Sgx6aRXRBXrYQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry/electron/node_modules/@sentry/node": {
-      "version": "10.27.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.27.0.tgz",
-      "integrity": "sha512-1cQZ4+QqV9juW64Jku1SMSz+PoZV+J59lotz4oYFvCNYzex8hRAnDKvNiKW1IVg5mEEkz98mg1fvcUtiw7GTiQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/context-async-hooks": "^2.2.0",
-        "@opentelemetry/core": "^2.2.0",
-        "@opentelemetry/instrumentation": "^0.208.0",
-        "@opentelemetry/instrumentation-amqplib": "0.55.0",
-        "@opentelemetry/instrumentation-connect": "0.52.0",
-        "@opentelemetry/instrumentation-dataloader": "0.26.0",
-        "@opentelemetry/instrumentation-express": "0.57.0",
-        "@opentelemetry/instrumentation-fs": "0.28.0",
-        "@opentelemetry/instrumentation-generic-pool": "0.52.0",
-        "@opentelemetry/instrumentation-graphql": "0.56.0",
-        "@opentelemetry/instrumentation-hapi": "0.55.0",
-        "@opentelemetry/instrumentation-http": "0.208.0",
-        "@opentelemetry/instrumentation-ioredis": "0.56.0",
-        "@opentelemetry/instrumentation-kafkajs": "0.18.0",
-        "@opentelemetry/instrumentation-knex": "0.53.0",
-        "@opentelemetry/instrumentation-koa": "0.57.0",
-        "@opentelemetry/instrumentation-lru-memoizer": "0.53.0",
-        "@opentelemetry/instrumentation-mongodb": "0.61.0",
-        "@opentelemetry/instrumentation-mongoose": "0.55.0",
-        "@opentelemetry/instrumentation-mysql": "0.54.0",
-        "@opentelemetry/instrumentation-mysql2": "0.55.0",
-        "@opentelemetry/instrumentation-pg": "0.61.0",
-        "@opentelemetry/instrumentation-redis": "0.57.0",
-        "@opentelemetry/instrumentation-tedious": "0.27.0",
-        "@opentelemetry/instrumentation-undici": "0.19.0",
-        "@opentelemetry/resources": "^2.2.0",
-        "@opentelemetry/sdk-trace-base": "^2.2.0",
-        "@opentelemetry/semantic-conventions": "^1.37.0",
-        "@prisma/instrumentation": "6.19.0",
-        "@sentry/core": "10.27.0",
-        "@sentry/node-core": "10.27.0",
-        "@sentry/opentelemetry": "10.27.0",
-        "import-in-the-middle": "^2",
-        "minimatch": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry/electron/node_modules/@sentry/node-core": {
-      "version": "10.27.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.27.0.tgz",
-      "integrity": "sha512-Dzo1I64Psb7AkpyKVUlR9KYbl4wcN84W4Wet3xjLmVKMgrCo2uAT70V4xIacmoMH5QLZAx0nGfRy9yRCd4nzBg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@apm-js-collab/tracing-hooks": "^0.3.1",
-        "@sentry/core": "10.27.0",
-        "@sentry/opentelemetry": "10.27.0",
-        "import-in-the-middle": "^2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.1.0 || ^2.2.0",
-        "@opentelemetry/core": "^1.30.1 || ^2.1.0 || ^2.2.0",
-        "@opentelemetry/instrumentation": ">=0.57.1 <1",
-        "@opentelemetry/resources": "^1.30.1 || ^2.1.0 || ^2.2.0",
-        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0 || ^2.2.0",
-        "@opentelemetry/semantic-conventions": "^1.37.0"
-      }
-    },
-    "node_modules/@sentry/electron/node_modules/@sentry/opentelemetry": {
-      "version": "10.27.0",
-      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.27.0.tgz",
-      "integrity": "sha512-z2vXoicuGiqlRlgL9HaYJgkin89ncMpNQy0Kje6RWyhpzLe8BRgUXlgjux7WrSrcbopDdC1OttSpZsJ/Wjk7fg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "10.27.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.1.0 || ^2.2.0",
-        "@opentelemetry/core": "^1.30.1 || ^2.1.0 || ^2.2.0",
-        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0 || ^2.2.0",
-        "@opentelemetry/semantic-conventions": "^1.37.0"
-      }
-    },
     "node_modules/@sentry/nextjs": {
       "version": "10.28.0",
       "resolved": "https://registry.npmjs.org/@sentry/nextjs/-/nextjs-10.28.0.tgz",
@@ -10363,10 +10170,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@spotlightjs/spotlight": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@spotlightjs/spotlight/-/spotlight-4.7.0.tgz",
-      "integrity": "sha512-Jh24VP0DoeE5HJ2S8dc/ogaukC1G6Q9vJEY7bRuxhhcxTq+/5w9yCp6KHszffdFbraXRHw+BkA8a6kaMCQeF1g==",
+    "node_modules/@spotlightjs/overlay": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@spotlightjs/overlay/-/overlay-4.5.0.tgz",
+      "integrity": "sha512-Pn8qnVI68082y/RCuZXX6lUctMRFxH5v48IctbC8WogOCWZ3VSdZoKqCAcDQpafZwTgoGADGPp/vIeYyqfNCaQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@spotlightjs/sidecar": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@spotlightjs/sidecar/-/sidecar-2.5.0.tgz",
+      "integrity": "sha512-KCkADnSMqt65LpfX99clXrUqG+ROPjbQfXxSLkZ5uPZ0t0NwOVd+CjYPH7siNl1CBQGCrLm0vgJ2USbaWzGk3g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -10375,32 +10189,26 @@
         "@jridgewell/trace-mapping": "^0.3.25",
         "@modelcontextprotocol/sdk": "^1.16.0",
         "@sentry/core": "^10",
-        "@sentry/electron": "^7.3.0",
-        "@sentry/node": "^10.28.0",
-        "@types/semver": "^7.7.1",
+        "@sentry/node": "^10.22.0",
         "chalk": "^5.6.2",
-        "electron-store": "^10.0.0",
-        "electron-updater": "^6.3.9",
         "eventsource": "^4.0.0",
         "fast-fuzzy": "^1.12.0",
         "hono": "^4.10.3",
-        "import-meta-resolve": "^4.1.0",
         "launch-editor": "^2.9.1",
         "logfmt": "^1.4.0",
         "mcp-proxy": "^5.6.0",
-        "semver": "^7.7.3",
         "uuidv7": "^1.0.2",
         "yaml": "^2.8.1",
         "zod": "^3"
       },
       "bin": {
-        "spotlight": "dist/run.js"
+        "spotlight-sidecar": "dist/run.js"
       },
       "engines": {
         "node": ">=20"
       }
     },
-    "node_modules/@spotlightjs/spotlight/node_modules/zod": {
+    "node_modules/@spotlightjs/sidecar/node_modules/zod": {
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
@@ -10408,6 +10216,25 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@spotlightjs/spotlight": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@spotlightjs/spotlight/-/spotlight-4.5.1.tgz",
+      "integrity": "sha512-PtoYz7ov/owm2PBrV9DY11CTNkQWsC6eiWKOM0e+M40E1/AfgtlhMTYLFA4+qk1Ifh8AazDD0tcfPFUQuDZDxQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sentry/node": "^10.22.0",
+        "@spotlightjs/overlay": "4.5.0",
+        "@spotlightjs/sidecar": "2.5.0",
+        "import-meta-resolve": "^4.1.0"
+      },
+      "bin": {
+        "spotlight": "dist/run.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@stablelib/base64": {
@@ -13720,20 +13547,6 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
     },
-    "node_modules/builder-util-runtime": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.3.1.tgz",
-      "integrity": "sha512-2/egrNDDnRaxVwK3A+cJq6UOlqOdedGA7JPqCeJjN2Zjk1/QB/6QUi3b714ScIGS7HafFXTyzJEOr5b44I3kvQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4",
-        "sax": "^1.2.4"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/builtin-modules": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-5.0.0.tgz",
@@ -16033,160 +15846,11 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/electron-store": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/electron-store/-/electron-store-10.1.0.tgz",
-      "integrity": "sha512-oL8bRy7pVCLpwhmXy05Rh/L6O93+k9t6dqSw0+MckIc3OmCTZm6Mp04Q4f/J0rtu84Ky6ywkR8ivtGOmrq+16w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "conf": "^14.0.0",
-        "type-fest": "^4.41.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/electron-store/node_modules/atomically": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.0.tgz",
-      "integrity": "sha512-+gDffFXRW6sl/HCwbta7zK4uNqbPjv4YJEAdz7Vu+FLQHe77eZ4bvbJGi4hE0QPeJlMYMA3piXEr1UL3dAwx7Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "stubborn-fs": "^2.0.0",
-        "when-exit": "^2.1.4"
-      }
-    },
-    "node_modules/electron-store/node_modules/conf": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/conf/-/conf-14.0.0.tgz",
-      "integrity": "sha512-L6BuueHTRuJHQvQVc6YXYZRtN5vJUtOdCTLn0tRYYV5azfbAFcPghB5zEE40mVrV6w7slMTqUfkDomutIK14fw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "atomically": "^2.0.3",
-        "debounce-fn": "^6.0.0",
-        "dot-prop": "^9.0.0",
-        "env-paths": "^3.0.0",
-        "json-schema-typed": "^8.0.1",
-        "semver": "^7.7.2",
-        "uint8array-extras": "^1.4.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/electron-store/node_modules/debounce-fn": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-6.0.0.tgz",
-      "integrity": "sha512-rBMW+F2TXryBwB54Q0d8drNEI+TfoS9JpNTAoVpukbWEhjXQq4rySFYLaqXMFXwdv61Zb2OHtj5bviSoimqxRQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-function": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/electron-store/node_modules/dot-prop": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-9.0.0.tgz",
-      "integrity": "sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^4.18.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/electron-store/node_modules/env-paths": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
-      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/electron-store/node_modules/json-schema-typed": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
-      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/electron-store/node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.264",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.264.tgz",
       "integrity": "sha512-1tEf0nLgltC3iy9wtlYDlQDc5Rg9lEKVjEmIHJ21rI9OcqkvD45K1oyNIRA4rR1z3LgJ7KeGzEBojVcV6m4qjA==",
       "license": "ISC"
-    },
-    "node_modules/electron-updater": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.6.2.tgz",
-      "integrity": "sha512-Cr4GDOkbAUqRHP5/oeOmH/L2Bn6+FQPxVLZtPbcmKZC63a1F3uu5EefYOssgZXG3u/zBlubbJ5PJdITdMVggbw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "builder-util-runtime": "9.3.1",
-        "fs-extra": "^10.1.0",
-        "js-yaml": "^4.1.0",
-        "lazy-val": "^1.0.5",
-        "lodash.escaperegexp": "^4.1.2",
-        "lodash.isequal": "^4.5.0",
-        "semver": "^7.6.3",
-        "tiny-typed-emitter": "^2.1.0"
-      }
-    },
-    "node_modules/electron-updater/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -21754,13 +21418,6 @@
         "shell-quote": "^1.8.3"
       }
     },
-    "node_modules/lazy-val": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
-      "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lazystream": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
@@ -22406,14 +22063,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
       "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "dev": true,
       "license": "MIT"
     },
@@ -23886,19 +23535,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/mimic-function": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
-      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/min-indent": {
@@ -30359,13 +29995,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/sax": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.3.tgz",
-      "integrity": "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==",
-      "dev": true,
-      "license": "BlueOak-1.0.0"
-    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -31640,23 +31269,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/stubborn-fs": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-2.0.0.tgz",
-      "integrity": "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "stubborn-utils": "^1.0.1"
-      }
-    },
-    "node_modules/stubborn-utils": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/stubborn-utils/-/stubborn-utils-1.0.2.tgz",
-      "integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/style-loader": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.4.tgz",
@@ -32113,13 +31725,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/tiny-typed-emitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
-      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
       "dev": true,
       "license": "MIT"
     },
@@ -32604,19 +32209,6 @@
       },
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/uint8array-extras": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
-      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/unbox-primitive": {
@@ -33853,13 +33445,6 @@
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
       }
-    },
-    "node_modules/when-exit": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
-      "integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@next/bundle-analyzer": "^16.0.7",
     "@next/eslint-plugin-next": "^16.0.7",
     "@playwright/test": "^1.57.0",
-    "@spotlightjs/spotlight": "^4.7.0",
+    "@spotlightjs/spotlight": "4.5.1",
     "@storybook/addon-a11y": "^10.1.4",
     "@storybook/addon-docs": "^10.1.4",
     "@storybook/addon-vitest": "^10.1.4",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated runtime and framework libraries (Next.js, React, Clerk, Sentry, PostHog, next-intl) and aligned Storybook/Vitest toolchains.
  * Applied minor version bumps to testing, linting and developer tools (Vitest, ESLint plugins, Storybook, bundle analyzer, lefthook, etc.) for stability and compatibility.
  * Adjusted some package version specifiers for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->