### PR TITLE
test: add unit tests for getBaseUrl and CounterValidation

### DIFF
--- a/src/utils/Helpers.test.ts
+++ b/src/utils/Helpers.test.ts
@@ -1,21 +1,45 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { routing } from '@/libs/I18nRouting';
-import { getI18nPath } from './Helpers';
+import { getBaseUrl, getI18nPath } from './Helpers';
+
+vi.mock('@/libs/Env', () => ({
+  Env: {
+    get NEXT_PUBLIC_APP_URL() {
+      return process.env.TEST_APP_URL;
+    },
+  },
+}));
 
 describe('Helpers', () => {
   describe('getI18nPath', () => {
-    it('should not change the path for default language', () => {
+    it('returns the path unchanged for the default locale', () => {
       const url = '/random-url';
       const locale = routing.defaultLocale;
 
       expect(getI18nPath(url, locale)).toBe(url);
     });
 
-    it('should prepend the locale to the path for non-default language', () => {
+    it('prepends the locale to the path for a non-default locale', () => {
       const url = '/random-url';
       const locale = 'fr';
 
       expect(getI18nPath(url, locale)).toMatch(/^\/fr/);
+    });
+  });
+
+  describe('getBaseUrl', () => {
+    it('returns NEXT_PUBLIC_APP_URL when set', () => {
+      process.env.TEST_APP_URL = 'https://example.com';
+
+      expect(getBaseUrl()).toBe('https://example.com');
+
+      delete process.env.TEST_APP_URL;
+    });
+
+    it('falls back to localhost:3000 when NEXT_PUBLIC_APP_URL is not set', () => {
+      delete process.env.TEST_APP_URL;
+
+      expect(getBaseUrl()).toBe('http://localhost:3000');
     });
   });
 });

--- a/src/validations/CounterValidation.test.ts
+++ b/src/validations/CounterValidation.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { CounterValidation } from './CounterValidation';
+
+describe('CounterValidation', () => {
+  describe('increment', () => {
+    it('accepts value of 1', () => {
+      const result = CounterValidation.safeParse({ increment: 1 });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts value of 3', () => {
+      const result = CounterValidation.safeParse({ increment: 3 });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects value below 1', () => {
+      const result = CounterValidation.safeParse({ increment: 0 });
+
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects value above 3', () => {
+      const result = CounterValidation.safeParse({ increment: 4 });
+
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects non-number value', () => {
+      const result = CounterValidation.safeParse({ increment: 'abc' });
+
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects missing increment field', () => {
+      const result = CounterValidation.safeParse({});
+
+      expect(result.success).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add missing unit tests for `getBaseUrl()` in `Helpers.ts` (2 tests covering both branches)
- Add unit tests for `CounterValidation` Zod schema (6 tests covering valid/invalid inputs)
- Update existing `getI18nPath` test titles to follow project conventions

## Test plan
- [x] All 10 unit tests pass (`vitest run --project unit`)
- [x] ESLint passes with no errors
- [x] TypeScript type checking passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for base URL configuration with fallback behavior
  * Added validation tests for counter increment functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->