### PR TITLE
docs: fix .vscode/extensions.json filename typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,7 +524,7 @@ Then, you can open https://local.drizzle.studio with your favorite browser to ex
 
 ### VSCode information (optional)
 
-If you are VSCode user, you can have a better integration with VSCode by installing the suggested extension in `.vscode/extension.json`. The starter code comes up with Settings for a seamless integration with VSCode. The Debug configuration is also provided for frontend and backend debugging experience.
+If you are VSCode user, you can have a better integration with VSCode by installing the suggested extensions in `.vscode/extensions.json`. The starter code comes up with Settings for a seamless integration with VSCode. The Debug configuration is also provided for frontend and backend debugging experience.
 
 With the plugins installed in your VSCode, ESLint and Prettier can automatically fix the code and display errors. The same applies to testing: you can install the VSCode Vitest extension to automatically run your tests, and it also shows the code coverage in context.
 


### PR DESCRIPTION
The README references .vscode/extension.json, but the file is .vscode/extensions.json. Also made "extension" plural to read correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the VS Code setup guidance to point to the correct recommended extensions configuration file name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->